### PR TITLE
Create a single windows credential file

### DIFF
--- a/docs/how_to/how_to_setup_environment.md
+++ b/docs/how_to/how_to_setup_environment.md
@@ -34,20 +34,59 @@ token: your_token
 EOL
 ```
 
-Configure SSH access for VMPooler VMs:
+Create a 'secrets' directory:
 
 ```bash
 # Create SSH config directory for VMPooler
-mkdir -p ~/.secrets/bolt/windows/ssh/vmpooler
+mkdir -p ~/.secrets/bolt/windows
+```
 
-# Create Windows credentials config
-cat << 'EOL' > ~/.secrets/bolt/windows/ssh/vmpooler/windows_credentials.yaml
-user: Administrator
-password: your_windows_password
+Export the windows password as an environment variable making sure to inject the correct password for `<REPLACEME>`:
+
+```bash
+export WINDOWS_PASSWORD='<REPLACEME>'
+```
+
+Then either create an **SSH credential** file:
+
+```bash
+# create an SSH windows credentials config file
+cat << EOL > ~/.secrets/bolt/windows/credentials.yaml
+---
+# See <https://www.puppet.com/docs/bolt/latest/bolt_transports_reference.html#ssh>
+transport: ssh
+ssh:
+  user: Administrator
+  password: ${WINDOWS_PASSWORD}
+  encryption-algorithms: 
+    - aes128-ctr
+    - aes192-ctr
+    - aes256-ctr
+    - aes128-gcm@openssh.com
+    - aes256-gcm@openssh.com
+    - chacha20-poly1305@openssh.com
+  host-key-check: false
+  ssl: false
 EOL
+```
 
+or a **winrm credential** file:
+
+```bash
+cat << EOL > ~/.secrets/bolt/windows/credentials.yaml
+---
+# See <https://www.puppet.com/docs/bolt/latest/bolt_transports_reference.html#ssh>
+transport: winrm
+winrm:
+  user: Administrator
+  password: ${WINDOWS_PASSWORD}
+  ssl: false
+EOL
+```
+
+```bash
 # Set appropriate permissions
-chmod 600 ~/.secrets/bolt/windows/ssh/vmpooler/windows_credentials.yaml
+chmod 600 ~/.secrets/bolt/windows/credentials.yaml
 ```
 
 ### Install direnv

--- a/docs/how_to/how_to_use_as_a_gem.md
+++ b/docs/how_to/how_to_use_as_a_gem.md
@@ -141,7 +141,7 @@ groups:
     transport: ssh
     ssh:
       _plugin: yaml
-      filepath: "~/.secrets/bolt/windows/ssh/vmpooler/windows_credentials.yaml"
+      filepath: "~/.secrets/bolt/windows/credentials.yaml"
   facts:
     role: windows
   targets:

--- a/lib/bolt_dynamic_inventory/provider/vmpooler/inventory.rb
+++ b/lib/bolt_dynamic_inventory/provider/vmpooler/inventory.rb
@@ -62,11 +62,8 @@ module BoltDynamicInventory
             {
               'name' => 'windows',
               'config' => {
-                'transport' => 'ssh',
-                'ssh' => {
-                  '_plugin' => 'yaml',
-                  'filepath' => '~/.secrets/bolt/windows/ssh/vmpooler/windows_credentials.yaml'
-                }
+                '_plugin' => 'yaml',
+                'filepath' => '~/.secrets/bolt/windows/credentials.yaml'
               },
               'facts' => { 'role' => 'windows' },
               'targets' => windows_targets

--- a/spec/bolt_dynamic_inventory_spec.rb
+++ b/spec/bolt_dynamic_inventory_spec.rb
@@ -120,9 +120,9 @@ RSpec.describe BoltDynamicInventory do
         windows_group = result['groups'].find { |g| g['name'] == 'windows' }
         expect(windows_group['targets']).to contain_exactly('onetime-algebra')
         expect(windows_group['facts']).to eq('role' => 'windows')
-        expect(windows_group['config']['ssh']).to include(
+        expect(windows_group['config']).to include(
           '_plugin' => 'yaml',
-          'filepath' => '~/.secrets/bolt/windows/ssh/vmpooler/windows_credentials.yaml'
+          'filepath' => '~/.secrets/bolt/windows/credentials.yaml'
         )
 
         # Check linux group


### PR DESCRIPTION
I've updated the documentation so the user can decide whether to use ssh or winrm transport to connect to the windows servers with the bolt inventory.