### PR TITLE
Fix warnings in gemspec

### DIFF
--- a/bolt_dynamic_inventory.gemspec
+++ b/bolt_dynamic_inventory.gemspec
@@ -17,7 +17,6 @@ Gem::Specification.new do |spec|
   spec.metadata['allowed_push_host'] = "TODO: Set to 'http://mygemserver.com'"
 
   spec.metadata['homepage_uri'] = spec.homepage
-  spec.metadata['source_code_uri'] = spec.homepage
   spec.metadata['changelog_uri'] = "#{spec.homepage}/blob/main/CHANGELOG.md"
 
   # Specify which files should be added to the gem when it is released.
@@ -31,7 +30,7 @@ Gem::Specification.new do |spec|
                         ])
 
   # Runtime dependencies
-  spec.add_dependency 'vmfloaty'
+  spec.add_dependency 'vmfloaty', '~> 1.8'
   spec.bindir        = 'exe'
   spec.executables   = spec.files.grep(%r{\Aexe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']


### PR DESCRIPTION
This fixes this:

```
➜  bolt_dynamic_inventory git:(update_rubocop_versions) gem build bolt_dynamic_inventory.gemspec
WARNING:  open-ended dependency on vmfloaty (>= 0) is not recommended
  use a bounded requirement, such as "~> x.y"
WARNING:  You have specified the uri:
  https://github.com/gavindidrichsen/bolt_dynamic_inventory
for all of the following keys:
  homepage_uri
  source_code_uri
Only the first one will be shown on rubygems.org
WARNING:  See https://guides.rubygems.org/specification-reference/ for help
  Successfully built RubyGem
  Name: bolt_dynamic_inventory
  Version: 0.2.0
  File: bolt_dynamic_inventory-0.2.0.gem
➜  bolt_dynamic_inventory git:(update_rubocop_versions)
```